### PR TITLE
Added new platforms to kitchen tests and disabled windows tests when not...

### DIFF
--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -7,6 +7,7 @@ driver_config:
   availability_zone: <%= ENV['AWS_AVAILABILITY_ZONE'] || 'us-east-1b' %>
   flavor_id: <%= ENV['AWS_FLAVOR_ID'] || 'm3.medium' %>
   iam_profile_name: <%= ENV['AWS_IAM_PROFILE'] %>
+  ssh_key: <%= ENV['EC2_SSH_KEY_PATH'] %>
 
 provisioner:
   name: chef_zero
@@ -16,6 +17,17 @@ platforms:
   - name: ubuntu-14.04-ec2
     driver_plugin: ec2
     driver_config:
-      image_id: <%=ENV['AWS_EC2_AMI'] %>
+      image_id: <%=ENV['AWS_UBUNTU_1404_AMI'] %>
       username: ubuntu
-      ssh_key: <%= ENV['EC2_SSH_KEY_PATH'] %>
+  - name: centos-6.5-ec2
+    driver_plugin: ec2
+    driver_config:
+      image_id: <%= ENV['AWS_CENTOS_65_AMI'] %>
+      username: root
+      ssh_timeout: 60
+      ssh_retries: 5
+  - name: amzn-linux-2014.09
+    driver_plugin: ec2
+    driver_config:
+      image_id: <%= ENV['AWS_AMAZON_201409_AMI'] %>
+      username: ec2-user

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,1 @@
 # 0.1.0
-
-Initial release of --no-thor

--- a/Gemfile
+++ b/Gemfile
@@ -4,14 +4,14 @@ gem 'berkshelf'
 gem 'emeril'
 
 group :style do
-  gem 'rubocop', '~> 0.18.0'
-  gem 'foodcritic', '~> 4.0'
+  gem 'rubocop'
+  gem 'foodcritic'
 end
 
 group :test do
   gem 'test-kitchen'
   gem 'kitchen-vagrant'
-  gem 'chefspec', '~> 4.1'
+  gem 'chefspec'
 end
 
 group :aws do

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,30 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+require 'bundler/setup'
+require 'emeril/rake'
+
+namespace :style do
+  require 'rubocop/rake_task'
+  desc 'Run rubocop for Ruby style checks'
+  RuboCop::RakeTask.new(:ruby)
+
+  require 'foodcritic'
+  desc 'Run foodcritic for Chef style checks'
+  FoodCritic::Rake::LintTask.new(:chef) do |t|
+    t.options = { :fail_tags => ['correctness'] }
+  end
+end
+
+desc 'Run all style checks'
+task style: ['style:chef', 'style:ruby']
+
+require 'rspec/core/rake_task'
+desc 'Run ChefSpec unit tests'
+RSpec::Core::RakeTask.new(:unit) do |t|
+  t.rspec_opts = "--color --format progress"
+end
+
+namespace :travis do
+  desc "run on Travis"
+  task ci: ['unit']
+end

--- a/spec/unit/recipes/_windows_spec.rb
+++ b/spec/unit/recipes/_windows_spec.rb
@@ -13,19 +13,22 @@
 #
 require_relative '../spec_helper'
 
-describe 'awscli::_windows' do
-  cached(:chef_run) do
-    ChefSpec::SoloRunner.new(platform: 'windows', version: '2012', log_level: :debug) do |node|
-      node.set['awscli']['windows_url'] = 'http://s3.amazonaws.com/fake/download/awscli.exe'
-    end.converge(described_recipe)
-  end
+# Run only on Windows
+if ::RbConfig::CONFIG['host_os'] =~ /mswin|mingw32|windows/
+  describe 'awscli::_windows' do
+    cached(:chef_run) do
+      ChefSpec::ServerRunner.new(platform: 'windows', version: '2012') do |node|
+        node.set['awscli']['windows_url'] = 'http://s3.amazonaws.com/fake/download/awscli.exe'
+      end.converge(described_recipe)
+    end
 
-  it 'includes the windows cookbook recipe' do
-    expect(chef_run).to include_recipe('windows')
-  end
+    it 'includes the windows cookbook recipe' do
+      expect(chef_run).to include_recipe('windows')
+    end
 
-  it 'installs awscli directly from a download link' do
-    expect(chef_run).to install_windows_package('AWS Command Line Interface')
-      .with_source('http://s3.amazonaws.com/fake/download/awscli.exe')
+    it 'installs awscli directly from a download link' do
+      expect(chef_run).to install_windows_package('AWS Command Line Interface')
+        .with_source('http://s3.amazonaws.com/fake/download/awscli.exe')
+    end
   end
 end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -14,14 +14,16 @@
 require_relative '../spec_helper'
 
 describe 'awscli::default' do
+  # Run only on Windows
+  if ::RbConfig::CONFIG['host_os'] =~ /mswin|mingw32|windows/
+    context 'windows' do
+      let(:chef_run) do
+        ChefSpec::SoloRunner.new(platform: 'windows', version: '2012').converge(described_recipe)
+      end
 
-  context 'windows' do
-    let(:chef_run) do
-      ChefSpec::SoloRunner.new(platform: 'windows', version: '2012').converge(described_recipe)
-    end
-
-    it 'includes the windows recipe' do
-      expect(chef_run).to include_recipe('awscli::_windows')
+      it 'includes the windows recipe' do
+        expect(chef_run).to include_recipe('awscli::_windows')
+      end
     end
   end
 


### PR DESCRIPTION
... on windows.
- Added Centos-6.5 and Amazon Linux 2014.09 platforms to AWS integration tests.
- Added Windows platform detection to the windows specific spec tests. The
  Windows tests are disabled unless they are run on a Windows host.
