### PR TITLE
Adding guards to prevent Chef 11 issues with source_url and issues_url.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,8 +5,8 @@ license 'Apache 2.0'
 description 'Defines a number of LWRP wrapper commands around the awscli command line script'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '1.1.1'
-source_url 'https://github.com/awslabs/awscli-cookbook'
-issues_url 'https://github.com/awslabs/awscli-cookbook/issues'
+source_url 'https://github.com/awslabs/awscli-cookbook' if respond_to?(:source_url)
+issues_url 'https://github.com/awslabs/awscli-cookbook/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu'
 supports 'centos'


### PR DESCRIPTION
When trying to upload the cookbook to my Chef server I would experience this error:

```
$ knife cookbook upload awscli                             
ERROR: knife encountered an unexpected error
This may be a bug in the 'cookbook upload' knife command or plugin
Please collect the output of this command with the `-VV` option before filing a bug report.
Exception: NoMethodError: undefined method `source_url' for #<Chef::Cookbook::Metadata:0x000000051b4478>
```

This commit places guards around the offending statements in `metadata.rb` - copied the solution found here: https://github.com/redguide/nodejs/pull/79
