### PR TITLE
lwrp for config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,53 @@ awscli_s3_file '/tmp/testfile' do
 end
 ```
 
+### awscli_config
+#### Actions
+<table>
+  <tr>
+    <th>Action</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td>:create</td>
+    <td>Creates awscli config for specified user</td>
+  </tr>
+</table>
+
+#### Attribute Parameters
+<table>
+  <tr>
+    <th>Parameter</th>
+    <th>Description</th>
+    <th>Default</th>
+  </tr>
+  <tr>
+    <td>homedir</td>
+    <td>home directory</td>
+    <td>/home/username</td>
+  </tr>
+  <tr>
+    <td>region</td>
+    <td>AWS region</td>
+    <td>us-east-1</td>
+  </tr>
+  <tr>
+    <td>credentials_databag</td>
+    <td>Data bag containing AWS credentials</td>
+    <td>nil</td>
+  </tr>
+</table>
+
+#### Usage Examples
+```ruby
+# Provide data bag containing credentials for config file
+awscli_config 'postgres' do
+  homedir '/var/lib/pgsql'
+  credentials_databag 'postgres_iam_keys'
+  region 'us-west-2'
+end
+```
+
 Testing
 -------
 In order to run the integration tests for this cookbook, you must have a valid AWS account and go through a few setup steps.

--- a/providers/config.rb
+++ b/providers/config.rb
@@ -1,0 +1,24 @@
+action :create do
+  username = new_resource.name
+  homedir = new_resource.homedir || "/home/#{username}"
+  region = new_resource.region || "us-east-1"
+  credentials = Chef::EncryptedDataBagItem.load('secrets', "#{new_resource.credentials_databag}")
+
+  directory "#{homedir}/.aws" do
+    owner username
+    group username
+    mode 0700
+  end
+
+  template "#{homedir}/.aws/config" do
+    cookbook "awscli"
+    source "awscli_config.erb"
+    owner username
+    group username
+    mode 0600
+    variables({
+      :region => region,
+      :credentials => credentials
+    })
+  end
+end

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -1,0 +1,7 @@
+actions :create
+default_action :create
+
+attribute :name, :name_attribute => true, :kind_of => String, :required => true
+attribute :homedir, :kind_of => String
+attribute :region, :kind_of => String
+attribute :credentials_databag, :kind_of => String, :required => true

--- a/templates/default/awscli_config.erb
+++ b/templates/default/awscli_config.erb
@@ -1,0 +1,4 @@
+[default]
+region = <%= @region %>
+aws_access_key_id = <%= @credentials['access_key_id'] %>
+aws_secret_access_key = <%= @credentials['secret_access_key'] %>


### PR DESCRIPTION
Addresses #10.

I know the other LWRP (for `s3_file`) has you pass along your AWS keys as parameters for the resource, but that seems insecure to me, as I suspect most people/organizations commit their cookbooks to Github or other version control system.

My LWRP requires you to pass in a databag ID, from which it then loads the credentials to be stored in `~/.aws/config` file.
