### PR TITLE
Update README.md with new owner/maintainer info

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 *** DEPRECATED ***
 ==================
 
-This repository is deprecated in favour of the https://github.com/nickryand/cloudcli-cookbook fork.
+This repository is deprecated in favour of the https://github.com/cmlicata/cloudcli-cookbook fork.
 
 ---
 


### PR DESCRIPTION
Just updated the link to reflect the change in owner/maintainer of the cloudcli cookbook